### PR TITLE
ci: assign each workflow to the same global queue, and prohibit cance…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "pages"
+  group: global-workflow-queue
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/unpublish.yml
+++ b/.github/workflows/unpublish.yml
@@ -13,7 +13,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "pages"
+  group: global-workflow-queue
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
…lling workflows in progress. This way all workflows will run sequentially to hopefully avoid interferance, but unfortunately more time may be spent in queue to complete
